### PR TITLE
update documentation to use protobufjs-cli for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ tool and it will generate a BIP39 seed for you.
 
 Install the protobufjs tool globally with:
 
-    npm install -g protobuf.js
+    npm install -g protobufjs-cli
 
 Then run:
 


### PR DESCRIPTION
The `pbjs` command doesn't include the cli utility anymore. This is now handled by `protobufjs-cli`.

See also https://github.com/protobufjs/protobuf.js/tree/master#nodejs